### PR TITLE
 Add URLs for Hussein Hany in ContributorCard

### DIFF
--- a/docs/about-us/contributors.mdx
+++ b/docs/about-us/contributors.mdx
@@ -23,6 +23,9 @@ import ContributorCard from '../../src/components/ContributorCard';
     name="Hussein Hany"
     role="Community Moderator"
     imageSrc="https://avatars.githubusercontent.com/u/37001450?v=4"
+    githubUrl="https://github.com/3ein39"
+    linkedinUrl="https://www.linkedin.com/in/3ein39/"
+    websiteUrl="https://3ein39.me/"
 />
 
 <ContributorCard name="Abdooo Nasser" role="Community Moderator" />


### PR DESCRIPTION
This pull request adds the GitHub, LinkedIn, and personal website URLs for Hussein Hany in the contributors.mdx file. The ContributorCard component for Hussein Hany has been updated with the respective URLs.  

**Changes made**:  
1. Added GitHub URL for Hussein Hany
2. Added LinkedIn URL for Hussein Hany
3. Added personal website URL for Hussein Hany